### PR TITLE
fix wrong command name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # webman-migration
  和laravel migration 使用方法类似
-- php webman migrate:created create_users_table 生成迁移文件
-- php webman migrate:created create_users_table --path=admin 生成迁移文件是指定目录
+- php webman migrate:create create_users_table 生成迁移文件
+- php webman migrate:create create_users_table --path=admin 生成迁移文件是指定目录
 - php webman migrate:run  执行迁移
 - php webman migrate:run  --path=admin 执行指定目录的迁移
 - php webman migrate:rollback 回滚迁移
 - php webman migrate:status 查看迁移状态
 - php webman migrate:fresh 
 - php webman seed:run 执行数据填充
-- php webman seed:created UserSeeder 生成数据填充文件
+- php webman seed:create UserSeeder 生成数据填充文件
 
 
 指定数据库连接


### PR DESCRIPTION
修正 README 中錯誤的指令名稱（不知道為什麼每個 `create` 後面都多了一個 d，但實際上指令名稱沒有那個 d）